### PR TITLE
uses `exec` instead of `wasm_tester` for `compile`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.0.15] - 2023-18-17
+
+### Added
+
+- `compile` now calls Circom subprocess instead of using WASM tester. This provides better control over cmdline args, e.g. we can call `--inspect` and `--O2` and such. [#20](https://github.com/erhant/circomkit/issues/20)
+- Added `inspect` option to config, defaulting to `true`.
+- Added `--O2` and `--O2round` optimization levels by allowing `optimization` to be any number. If optimization is greater than 2, it corresponds to `--O2round` with the max round number as optimization level.
+
 ## [0.0.14] - 2023-18-15
 
 ### Added

--- a/circomkit.json
+++ b/circomkit.json
@@ -1,3 +1,4 @@
 {
-  "version": "2.1.4"
+  "version": "2.1.4",
+  "verbose": true
 }

--- a/src/types/circomkit.ts
+++ b/src/types/circomkit.ts
@@ -22,11 +22,15 @@ export type CircomkitConfig = {
   /** Version number for main components. */
   version: `${number}.${number}.${number}`;
   /**
-   * Optimization level.
+   * [Optimization level](https://docs.circom.io/getting-started/compilation-options/#flags-and-options-related-to-the-r1cs-optimization).
    * - `0`: No simplification is applied.
    * - `1`: Only applies `var` to `var` and `var` to `constant` simplification.
+   * - `2`: Full constraint simplificiation via Gaussian eliminations.
+   * - `>2`: Any number higher than 2 will use `--O2round` with the number as simplification rounds.
    */
-  optimization: 0 | 1;
+  optimization: number;
+  /** Does an additional check over the constraints produced. */
+  inspect: boolean;
   /** Include paths as libraries during compilation. */
   include: string[];
   /** Pass logger to SnarkJS to see its logs in addition to Circomkit */

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -18,6 +18,7 @@ export const defaultConfig: Readonly<CircomkitConfig> = Object.seal({
   dirBuild: './build',
   // compiler-specific
   optimization: 1,
+  inspect: true,
   include: ['./node_modules'],
   // groth16 phase-2 settings
   groth16numContributions: 1,


### PR DESCRIPTION
Also added `inspect` and `optimization >= 2` compile options.

Note that WitnessTester does not use `optimization >=2`.