### PR TITLE
refactor(setup): remove initPhase2 and add extract vKey method

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -82,6 +82,13 @@ async function cli(): Promise<number> {
       break;
     }
 
+    case 'vkey': {
+      titleLog('Extracting verification key');
+      const path = await circomkit.vkey(process.argv[3], process.argv[4]);
+      circomkit.log('Created at: ' + path, 'success');
+      break;
+    }
+
     case 'prove': {
       titleLog('Generating proof');
       const path = await circomkit.prove(process.argv[3], process.argv[4] || DEFAULT_INPUT);

--- a/src/circomkit.ts
+++ b/src/circomkit.ts
@@ -445,7 +445,6 @@ export class Circomkit {
       // generate genesis zKey
       let curZkey = this.pathZkey(circuit, 0);
       await snarkjs.zKey.newZKey(r1csPath, ptauPath, curZkey, this.snarkjsLogger);
-      rmSync(ptauPath);
 
       // make contributions
       for (let contrib = 1; contrib <= this.config.groth16numContributions; contrib++) {

--- a/src/circomkit.ts
+++ b/src/circomkit.ts
@@ -151,6 +151,26 @@ export class Circomkit {
     ]);
   }
 
+  /** Export a verification key (vKey) from a zKey */
+  async vkey(circuit: string, pkeyPath?: string): Promise<string> {
+    const vkeyPath = this.path(circuit, 'vkey');
+
+    // check if it exists
+    if (pkeyPath === undefined) {
+      pkeyPath = this.path(circuit, 'pkey');
+    }
+
+    if (!existsSync(pkeyPath)) {
+      throw new Error('There must be a prover key for this circuit to extract a verification key.');
+    }
+
+    // extract it
+    const vkey = await snarkjs.zKey.exportVerificationKey(pkeyPath, this.snarkjsLogger);
+    writeFileSync(vkeyPath, prettyStringify(vkey));
+
+    return vkeyPath;
+  }
+
   /** Information about circuit. */
   async info(circuit: string): Promise<R1CSInfoType> {
     // we do not pass `this.snarkjsLogger` here on purpose
@@ -182,6 +202,8 @@ export class Circomkit {
     if (this.config.prime !== 'bn128') {
       throw new Error('Auto-downloading PTAU only allowed for bn128 at the moment.');
     }
+
+    // @todo check for performance gains when larger PTAUs are found instead of the target PTAU
     const {constraints} = await this.info(circuit);
     const ptauName = getPtauName(constraints);
 
@@ -400,26 +422,30 @@ export class Circomkit {
     }
 
     // get ptau path
+    this.log('Checking for PTAU file...', 'debug');
+
     if (ptauPath === undefined) {
       if (this.config.prime !== 'bn128') {
         throw new Error('Please provide PTAU file when using a prime field other than bn128');
       }
-      this.log('Checking for PTAU file...', 'debug');
       ptauPath = await this.ptau(circuit);
+    } else {
+      // if the provided path does not exist, we can just download it
+      if (!existsSync(ptauPath)) {
+        // we can download it
+        ptauPath = await this.ptau(circuit);
+      }
     }
 
     // circuit specific setup
     this.log('Beginning setup phase!', 'info');
     if (this.config.protocol === 'groth16') {
-      // Groth16 needs a specific setup with its own PTAU ceremony
-      // initialize phase 2
-      const ptau2Init = this.pathPtau(`${circuit}_init.zkey`);
-      await snarkjs.powersOfTau.preparePhase2(ptauPath, ptau2Init, this.snarkjsLogger);
+      // Groth16 needs a circuit specific setup
 
-      // start PTAU generation
+      // generate genesis zKey
       let curZkey = this.pathZkey(circuit, 0);
-      await snarkjs.zKey.newZKey(r1csPath, ptau2Init, curZkey, this.snarkjsLogger);
-      rmSync(ptau2Init);
+      await snarkjs.zKey.newZKey(r1csPath, ptauPath, curZkey, this.snarkjsLogger);
+      rmSync(ptauPath);
 
       // make contributions
       for (let contrib = 1; contrib <= this.config.groth16numContributions; contrib++) {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -27,6 +27,9 @@ export const usageString = `Usage:
   Clean build artifacts & main component.
   > clean circuit
 
+  Export Verification Key (vKey.json).
+  > vkey circuit zKeyPath
+
   Export Solidity verifier.
   > contract circuit
   

--- a/src/utils/ptau.ts
+++ b/src/utils/ptau.ts
@@ -2,7 +2,7 @@ import {createWriteStream} from 'fs';
 import {get} from 'https';
 
 /** Base PTAU URL as seen in [SnarkJS docs](https://github.com/iden3/snarkjs#7-prepare-phase-2). */
-const PTAU_URL_BASE = 'https://hermez.s3-eu-west-1.amazonaws.com';
+const PTAU_URL_BASE = 'https://storage.googleapis.com/zkevm/ptau';
 
 /**
  * Returns the name of PTAU file for a given number of constraints.

--- a/tests/testers.test.ts
+++ b/tests/testers.test.ts
@@ -1,5 +1,5 @@
 import {Circomkit, ProofTester, WitnessTester} from '../src';
-import {BAD_INPUT, CIRCUIT_CONFIG, CIRCUIT_NAME, INPUT, N, OUTPUT} from './common';
+import {BAD_INPUT, CIRCUIT_CONFIG, CIRCUIT_NAME, INPUT, N, OUTPUT, PTAU_PATH} from './common';
 import {expect} from 'chai';
 
 describe('witness tester', () => {
@@ -69,7 +69,7 @@ describe('proof tester', () => {
       protocol: 'plonk',
     });
     circomkit.instantiate(CIRCUIT_NAME, CIRCUIT_CONFIG);
-    await circomkit.setup(CIRCUIT_NAME, './ptau/powersOfTau28_hez_final_08.ptau');
+    await circomkit.setup(CIRCUIT_NAME, PTAU_PATH);
     circuit = await circomkit.ProofTester(CIRCUIT_NAME);
   });
 


### PR DESCRIPTION
fix #50 

- [x] Remove [these lines](https://github.com/erhant/circomkit/blob/main/src/circomkit.ts#L414-L417) and use existing PTAU instead of thats being created ptau2init there
- [x] Update base URL for Perpetual Powers of Tau urls
- [x] Add an extract function that looks for the zKey (w.r.t circuit name and configured protocol) and generates the vKey
- [x] Add CLI wrapper that calls extract
- [x] No need to check if PTAUs for larger constrain counts exist as you mentioned above, but maybe we can add a comment TODO: check for performance gains when larger PTAUs are found instead of the target PTAU; I want to check that out sometime :)