### PR TITLE
Fix input length checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circomkit",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "A Circom development environment",
   "author": "erhant",
   "license": "MIT",

--- a/src/testers/witnessTester.ts
+++ b/src/testers/witnessTester.ts
@@ -72,13 +72,18 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
     await this.calculateWitness(input).then(
       () => assert.fail('Expected witness calculation to fail.'),
       err => {
-        expect(
-          [
-            'Error: Assert Failed.', // a constraint failure (most common)
-            'Not enough values for input signal', // few inputs than expected for a signal
-            'Too many values for input signal', // more inputs than expected for a signal
-          ].some(msg => (err as Error).message.startsWith(msg))
-        ).to.be.true;
+        const isExpectedError = [
+          'Error: Assert Failed.', // a constraint failure (most common)
+          'Not enough values for input signal', // few inputs than expected for a signal
+          'Too many values for input signal', // more inputs than expected for a signal
+        ].some(msg => (err as Error).message.startsWith(msg));
+        if (isExpectedError) {
+          // we expected this failure, register it as an expect call
+          expect(isExpectedError).to.be.true;
+        } else {
+          // we did not expect this failure, throw it anyways
+          throw err;
+        }
       }
     );
   }

--- a/src/testers/witnessTester.ts
+++ b/src/testers/witnessTester.ts
@@ -37,7 +37,7 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
 
   /** Compute witness given the input signals. */
   async calculateWitness(input: CircuitSignals<IN>): Promise<WitnessType> {
-    return this.circomWasmTester.calculateWitness(input, true);
+    return this.circomWasmTester.calculateWitness(input, false);
   }
 
   /** Returns the number of constraints. */
@@ -72,8 +72,13 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
     await this.calculateWitness(input).then(
       () => assert.fail('Expected witness calculation to fail.'),
       err => {
-        // console.log(err.message);
-        expect(err.message.startsWith('Error: Assert Failed.')).to.be.true;
+        expect(
+          [
+            'Error: Assert Failed.', // a constraint failure (most common)
+            'Not enough values for input signal', // few inputs than expected for a signal
+            'Too many values for input signal', // more inputs than expected for a signal
+          ].some(msg => (err as Error).message.startsWith(msg))
+        ).to.be.true;
       }
     );
   }

--- a/src/utils/calldata.ts
+++ b/src/utils/calldata.ts
@@ -1,5 +1,3 @@
-// import {CircomkitProtocol} from '../types';
-
 import type {FflonkProof, Groth16Proof, PlonkProof, PublicSignals} from 'snarkjs';
 
 /** Makes each value 32-bytes long hexadecimal. Does not check for overflows! */
@@ -103,7 +101,7 @@ function groth16Calldata(proof: Groth16Proof, pretty: boolean) {
 
   if (pretty) {
     return [
-      `uint[2] pA = [${pA.join(', ')}]`,
+      `uint[2] pA = [${pA.join(', ')}];`,
       `uint[2][2] pB = [[${pB0.join(', ')}], [${pB1.join(', ')}]];`,
       `uint[2] pC = [${pC.join(', ')}];`,
     ].join('\n');

--- a/tests/witnessTester.test.ts
+++ b/tests/witnessTester.test.ts
@@ -7,7 +7,7 @@ describe('witness tester', () => {
   const {
     circuit: {name, config, size, exact},
     signals,
-  } = prepareMultiplier(10);
+  } = prepareMultiplier(4);
 
   before(async () => {
     const circomkit = new Circomkit({verbose: false, logLevel: 'silent'});
@@ -16,13 +16,25 @@ describe('witness tester', () => {
 
   it('should have correct number of constraints', async () => {
     await circuit.expectConstraintCount(size!, exact);
+
+    // should also work for non-exact too, where we expect at least some amount
+    await circuit.expectConstraintCount(size!);
+    await circuit.expectConstraintCount(size! - 1);
   });
 
   it('should assert correctly', async () => {
     await circuit.expectPass(signals.input, signals.output);
   });
 
-  it('should fail for bad inupt', async () => {
+  it('should fail for fewer inputs than expected', async () => {
+    await circuit.expectFail({in: signals.input.in.slice(1)});
+  });
+
+  it('should fail for more inputs than expected', async () => {
+    await circuit.expectFail({in: [0, ...signals.input.in]});
+  });
+
+  it('should fail for bad witness', async () => {
     await circuit.expectFail(signals.badInput);
   });
 


### PR DESCRIPTION
- [x] `expectFail` now checks for input length errors as well.
- [x] If an unexpected error occurs during `expectFail`, it is thrown. This will make sure that `expectFail` will fail (although by throwing an error) if the method we check for errors require a change due to different error messages by SnarkJS at a later version.
- [x] Fix tiny typo for calldata