### PR TITLE
fix skipLibCheck, add plonk optim check, formatting

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -1,8 +1,8 @@
-import { HardhatUserConfig } from "hardhat/config";
-import "@nomicfoundation/hardhat-toolbox";
+import {HardhatUserConfig} from 'hardhat/config';
+import '@nomicfoundation/hardhat-toolbox';
 
 const config: HardhatUserConfig = {
-  solidity: "0.8.24",
+  solidity: '0.8.24',
 };
 
 export default config;

--- a/src/circomkit.ts
+++ b/src/circomkit.ts
@@ -67,7 +67,17 @@ export class Circomkit {
       throw new Error('Invalid protocol in configuration.');
     }
     if (this.config.optimization < 0) {
+      this.log('Optimization level must be at least 0, setting it to 0.', 'warn');
       this.config.optimization = 0;
+    }
+
+    // PLONK protocol requires optimization level to be 1
+    if (this.config.protocol === 'plonk' && this.config.optimization !== 1) {
+      this.log(
+        'Optimization level for PLONK must be 1.\nSee: https://docs.circom.io/circom-language/circom-insight/simplification/',
+        'warn'
+      );
+      this.config.optimization = 1;
     }
   }
 

--- a/tests/circomkit.test.ts
+++ b/tests/circomkit.test.ts
@@ -1,8 +1,10 @@
 import forEach from 'mocha-each';
-//@ts-ignore
-import { ethers } from "hardhat";
-//@ts-ignore
-import solc from "solc";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import {ethers} from 'hardhat';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+import solc from 'solc';
 import {PROTOCOLS} from '../src/utils/config';
 import {Circomkit} from '../src';
 import {expect} from 'chai';
@@ -87,23 +89,24 @@ forEach(PROTOCOLS).describe('protocol: %s', (protocol: (typeof PROTOCOLS)[number
     const source = readFileSync(path, {encoding: 'utf-8'})
       // XXX: snarkjs plonk template has an erroneous hardhat import
       //      See https://github.com/iden3/snarkjs/pull/464
+      //      TODO: Remove this fix when the PR is merged
       .replace('import "hardhat/console.sol";\n', '');
 
-    // Compile the contract
+    // compile the contract
     const input = {
       language: 'Solidity',
       sources: {
         'TestVerifier.sol': {
-          content: source
-        }
+          content: source,
+        },
       },
       settings: {
         outputSelection: {
           '*': {
-            '*': ['abi', 'evm.bytecode.object']
-          }
-        }
-      }
+            '*': ['abi', 'evm.bytecode.object'],
+          },
+        },
+      },
     };
 
     const output = JSON.parse(solc.compile(JSON.stringify(input)));
@@ -111,15 +114,18 @@ forEach(PROTOCOLS).describe('protocol: %s', (protocol: (typeof PROTOCOLS)[number
     const bytecode = output.contracts['TestVerifier.sol'][contractName].evm.bytecode.object;
     const abi = output.contracts['TestVerifier.sol'][contractName].abi;
 
-    // Deploy the contract using ethers
+    // deploy the contract using ethers
     const ContractFactory = new ethers.ContractFactory(abi, bytecode, (await ethers.getSigners())[0]);
     const contract = await ContractFactory.deploy();
     await contract.waitForDeployment();
 
-    // Interaction with the contract
+    // interaction with the contract
     const calldata = await circomkit.calldata(circuit.name, inputName);
-    const args = calldata.split('\n').filter(x=>!!x).map(x=>JSON.parse(x));
-    //@ts-ignore
+    const args = calldata
+      .split('\n')
+      .filter(x => !!x)
+      .map(x => JSON.parse(x));
+
     expect(await contract.verifyProof(...args)).to.equal(true);
   });
 

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "rootDir": "src",
     "outDir": "dist",
-    "noEmit": false
+    "noEmit": false,
+    "skipLibCheck": true
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
- add `skipLibCheck: true` due to Mocha lib type error
- Resolves #71 by setting optim to 1 for PLONK (see https://docs.circom.io/circom-language/circom-insight/simplification/ for why)
- Fix formatting within the merged #72 

@numtel can we decrease the number of hardhat libs added as dev dependency? do we really need all of them?