### PR TITLE
Add circomPath configuration parameter

### DIFF
--- a/src/circomkit.ts
+++ b/src/circomkit.ts
@@ -262,7 +262,7 @@ export class Circomkit {
     // call `circom` as a sub-process
     try {
       const result = await new Promise<{stdout: string; stderr: string}>((resolve, reject) => {
-        exec(`circom ${flags} ${targetPath}`, (error, stdout, stderr) => {
+        exec(`${this.config.circomPath} ${flags} ${targetPath}`, (error, stdout, stderr) => {
           if (error === null) {
             resolve({stdout, stderr});
           } else {

--- a/src/types/circomkit.ts
+++ b/src/types/circomkit.ts
@@ -23,6 +23,8 @@ export type CircomkitConfig = {
   dirPtau: string;
   /** Directory to output circuit build files. */
   dirBuild: string;
+  /** Path to circom executable */
+  circomPath: string;
   /** Number of contributions */
   groth16numContributions: number;
   /** Ask user input to create entropy */

--- a/src/utils/config.ts
+++ b/src/utils/config.ts
@@ -16,6 +16,7 @@ export const defaultConfig: Readonly<CircomkitConfig> = Object.seal({
   dirCircuits: './circuits',
   dirInputs: './inputs',
   dirBuild: './build',
+  circomPath: 'circom',
   // compiler-specific
   optimization: 1,
   inspect: true,


### PR DESCRIPTION
Hey Erhan,

Thanks for being receptive to that last PR. I've got another patch. This one is so that I can run multiple different versions of the circom executable inside AWS Lambda. I'm creating [Circuitscan, a circuit explorer](https://github.com/circuitscan/circuitscan) where people can verify their deployed verifier contracts.

Soon, I'm hoping to make a new circomkit feature where people can deploy and verify their circuits using an API call to circuitscan. (like how Foundry and Hardhat verify contracts on Etherscan) This will let people integrate circom deployments into CI builds very easily.

If you have any ideas for circuitscan let me know. It was one of the suggested projects for the EF ZK grants round back in March but I didn't get going until after those applications ended. I'm hoping I can get a grant at some point for this.

Ben