### PR TITLE
Optimize `r1cs` info reader

### DIFF
--- a/src/bin/index.ts
+++ b/src/bin/index.ts
@@ -54,12 +54,12 @@ async function cli(): Promise<number> {
       titleLog('Circuit information');
       const info = await circomkit.info(process.argv[3]);
       circomkit.log(`Prime Field: ${info.primeName}`);
-      circomkit.log(`Number of Wires: ${info.variables}`);
+      circomkit.log(`Number of Wires: ${info.wires}`);
       circomkit.log(`Number of Constraints: ${info.constraints}`);
       circomkit.log(`Number of Private Inputs: ${info.privateInputs}`);
       circomkit.log(`Number of Public Inputs: ${info.publicInputs}`);
+      circomkit.log(`Number of Public Outputs: ${info.publicOutputs}`);
       circomkit.log(`Number of Labels: ${info.labels}`);
-      circomkit.log(`Number of Outputs: ${info.outputs}`);
       break;
     }
 

--- a/src/types/circuit.ts
+++ b/src/types/circuit.ts
@@ -46,17 +46,17 @@ export type CircuitConfig = {
   params?: (number | bigint)[];
 };
 
-/** Some fields for the R1CS information returned by SnarkJS.
+/** Some fields for the R1CS information.
  * Many other fields are omitted in this type.
  */
 export type R1CSInfoType = {
-  variables: number;
+  wires: number;
   constraints: number;
   privateInputs: number;
   publicInputs: number;
+  publicOutputs: number;
   useCustomGates: boolean;
   labels: number;
-  outputs: number;
   prime: bigint;
   primeName: string;
 };

--- a/src/utils/r1cs.ts
+++ b/src/utils/r1cs.ts
@@ -1,0 +1,11 @@
+import {readSync, ReadPosition} from 'fs';
+
+/** Reads a specified number of bytes from a file and converts them to a BigInt.
+ */
+export function readBytesFromFile(fd: number, offset: number, length: number, position: ReadPosition): BigInt {
+  const buffer = Buffer.alloc(length);
+
+  readSync(fd, buffer, offset, length, position);
+
+  return BigInt(`0x${buffer.reverse().toString('hex')}`);
+}


### PR DESCRIPTION
# Description

This PR aims to replace the `r1cs.info()` method of `snarkjs` by manually extracting information from the R1CS file by reading its bytes via a pointer, according to the [R1CS specs - bin format](https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md). This optimisation brings considerable improvement on circuits and corresponding large files.

closes #58

### Credits
This was built taking inspiration from these implementations
- https://github.com/weijiekoh/circom-helper/blob/master/ts/read_num_inputs.ts#L5
- https://github.com/privacy-scaling-explorations/p0tion/blob/f88bcee5d499dce975d0592ed10b21aa8d73bbd2/packages/actions/src/helpers/utils.ts#L413
