### PR TITLE
fixes & new version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "circomkit",
-  "version": "0.0.25",
-  "description": "A Circom development environment",
+  "version": "0.1.0",
+  "description": "A Circom testing & development environment",
   "author": "erhant",
   "license": "MIT",
   "engines": {

--- a/src/circomkit.ts
+++ b/src/circomkit.ts
@@ -92,7 +92,7 @@ export class Circomkit {
   }
 
   /** Computes a path that requires a circuit name. */
-  private path(circuit: string, type: CircuitPathBuilders): string {
+  path(circuit: string, type: CircuitPathBuilders): string {
     const dir = `${this.config.dirBuild}/${circuit}`;
     switch (type) {
       case 'dir':
@@ -117,17 +117,17 @@ export class Circomkit {
   }
 
   /** Computes a path that requires a circuit and an input name. */
-  private pathWithInput(circuit: string, input: string, type: CircuitInputPathBuilders): string {
+  pathWithInput(circuit: string, input: string, type: CircuitInputPathBuilders): string {
     const dir = `${this.config.dirBuild}/${circuit}/${input}`;
     switch (type) {
       case 'dir':
         return dir;
+      case 'wtns':
+        return `${dir}/witness.wtns`;
       case 'pubs':
         return `${dir}/public.json`;
       case 'proof':
-        return `${dir}/proof.json`;
-      case 'wtns':
-        return `${dir}/witness.wtns`;
+        return `${dir}/${this.config.protocol}_proof.json`;
       case 'in':
         return `${this.config.dirInputs}/${circuit}/${input}.json`;
       default:
@@ -136,13 +136,13 @@ export class Circomkit {
   }
 
   /** Given a PTAU name, returns the relative path. */
-  private pathPtau(ptauName: string): string {
+  pathPtau(ptauName: string): string {
     return `${this.config.dirPtau}/${ptauName}`;
   }
 
   /** Given a circuit & id name, returns the relative path of the phase-2 PTAU.
    * This is used in particular by Groth16's circuit-specific setup phase. */
-  private pathZkey(circuit: string, id: number): string {
+  pathZkey(circuit: string, id: number): string {
     return `${this.config.dirBuild}/${circuit}/${circuit}_${id}.zkey`;
   }
 

--- a/src/circomkit.ts
+++ b/src/circomkit.ts
@@ -185,8 +185,10 @@ export class Circomkit {
   }
 
   /** Read the information about the circuit by extracting it from the R1CS file.
-   * This implementation follows the specs at
-   * https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md.
+   *
+   * This implementation follows the specs at [iden3/r1csfile](https://github.com/iden3/r1csfile/blob/master/doc/r1cs_bin_format.md)
+   * and is inspired from the work by [PSE's `p0tion`](https://github.com/privacy-scaling-explorations/p0tion/blob/f88bcee5d499dce975d0592ed10b21aa8d73bbd2/packages/actions/src/helpers/utils.ts#L413)
+   * and by [Weijiekoh's `circom-helper`](https://github.com/weijiekoh/circom-helper/blob/master/ts/read_num_inputs.ts#L5).
    */
   async info(circuit: string): Promise<R1CSInfoType> {
     let pointer = 0;

--- a/src/utils/r1cs.ts
+++ b/src/utils/r1cs.ts
@@ -1,7 +1,6 @@
 import {readSync, ReadPosition} from 'fs';
 
-/** Reads a specified number of bytes from a file and converts them to a BigInt.
- */
+/** Reads a specified number of bytes from a file and converts them to a `BigInt`. */
 export function readBytesFromFile(fd: number, offset: number, length: number, position: ReadPosition): BigInt {
   const buffer = Buffer.alloc(length);
 

--- a/tests/errors.test.ts
+++ b/tests/errors.test.ts
@@ -1,6 +1,6 @@
 import {Circomkit, WitnessTester} from '../src';
 
-describe('error catching', () => {
+describe('errors', () => {
   let circuit: WitnessTester<['in', 'inin'], ['out']>;
 
   before(async () => {
@@ -10,25 +10,30 @@ describe('error catching', () => {
 
   it('should fail for fewer inputs than expected', async () => {
     await circuit.expectFail({in: 0, inin: [1]});
+    // Not enough values for input signal inin
   });
 
   it('should fail for more inputs than expected', async () => {
     await circuit.expectFail({in: 0, inin: [1, 2, 3]});
+    // Too many values for input signal inin
   });
 
   it('should fail due to false-assert', async () => {
     await circuit.expectFail({in: 1, inin: [1, 2]});
+    // Error: Assert Failed.
   });
 
   it('should fail due to missing signal', async () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
-    await circuit.expectFail({inin: [1, 2, 3]});
+    await circuit.expectFail({inin: [1, 2]});
+    // Not all inputs have been set. Only 2 out of 3.
   });
 
   it('should fail due to extra signal', async () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-expect-error
     await circuit.expectFail({inin: [1, 2, 3], idontexist: 1});
+    // Too many values for input signal inin
   });
 });


### PR DESCRIPTION
- Resolves #60 by prefixing the protocol name behind the `_proof.json`, public signals are still `public.json` as they do not change w.r.t the protocol itself.
- Resolves #70 by handling that case, indeed it was missing.
- All `circomkit` path functions are public for better integrations with the existing pathing system.
- Some doc comments