### PR TITLE
Allow ommitting "template" circuit property to skip main component instantiation

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -235,6 +235,10 @@ export class Circomkit {
       };
     }
 
+    if (typeof circuitConfig.template === 'undefined') {
+      return `${this.config.dirCircuits}/${circuit}.circom`;
+    }
+
     // directory to output the file
     const directory = circuitConfig.dir || 'test';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,8 +34,8 @@ export type SymbolsType = {
 export type CircuitConfig = {
   /** File to read the template from */
   file: string;
-  /** The template name to instantiate */
-  template: string;
+  /** The template name to instantiate, undefined to skip instantiation (main template already exists)  */
+  template: string | undefined;
   /** Directory to instantiate at */
   dir?: string;
   /** Target version */

--- a/tests/circuits.json
+++ b/tests/circuits.json
@@ -9,5 +9,8 @@
     "template": "Arrays",
     "params": [2, 3],
     "pubs": ["in1D", "in2D"]
+  },
+  "has_main": {
+    "file": "has_main"
   }
 }

--- a/tests/circuits/has_main.circom
+++ b/tests/circuits/has_main.circom
@@ -1,0 +1,10 @@
+pragma circom 2.0.0;
+
+template MyTest() {
+  signal input in;
+  signal output out;
+
+  out <== in * 2;
+}
+
+component main = MyTest();

--- a/tests/configs.test.ts
+++ b/tests/configs.test.ts
@@ -78,6 +78,27 @@ describe('configuring the C witness generator', () => {
   });
 });
 
+describe('compiling without instantiating new main component', () => {
+  const CONFIG = {
+    verbose: false,
+    logLevel: 'silent',
+    dirPtau: './tests/ptau',
+    dirInputs: './tests/inputs',
+    dirBuild: './tests/build',
+    dirCircuits: './tests/circuits',
+    circuits: './tests/circuits.json',
+  } as const;
+  const CIRCUIT_NAME = 'has_main';
+
+  it('should compile correctly', async () => {
+    const circomkit = new Circomkit({...CONFIG});
+
+    const outPath = await circomkit.compile(CIRCUIT_NAME);
+    expect(existsSync(`${outPath}/${CIRCUIT_NAME}_js`)).toBe(true);
+    rmSync(`${outPath}/${CIRCUIT_NAME}_js`, {recursive: true});
+  });
+});
+
 describe('compiling under different directories', () => {
   const cases = [
     {


### PR DESCRIPTION
Hey Erhan,

I'm working on getting some more complex circuits compiled and I don't want to carve out more from my usage of circomkit from the circuitscan build artifacts so I've created this patch that will skip the main component instantiation and instead expect the circuit file to include the main component.

Some main components require more than the auto-generated main file, such as those generated from [PIL](https://github.com/0xPolygonHermez/pil-stark) which include
"pragma custom_templates".

In order to skip adding a special case for this pragma, this commit allows the developer to specify their own main component

Afaict, this is the only changes required to accomplish this.

Ben