### PR TITLE
[draft] Add C tester

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,30 +241,11 @@ You can compute the witness via the `calculateWitness(input)` function. To test 
 > });
 > ```
 
-#### Using C Tester
+#### Using C Tester (Work in Progress ⌛)
 
-You can make use of C-based tester as well. There is a prerequisite:
+You can make use of the C-tester as well, which performs much better for larger circuits than the WASM alternative.
 
-- Install `nlohmann-json` header that is included within the C code:
-- Install `nasm`
-- Install `gmp` (GNU Multi-precision Arithmetic Library)
-
-> [!TIP]
->
-> If you are using Mac you can do these with brew:
->
-> ```sh
->
-> # install required stuff
-> brew install nlohmann-json
-> brew install nasm
-> brew install gmp
->
-> # add brew to path if required, path may differ M2 / M1
-> export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/opt/homebrew/include/"
-> export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib"
-> export INCLUDE_PATH="$INCLUDE_PATH:/opt/homebrew/include"
-> ```
+There may be some prerequisites to compile, and we have an [issue on this](https://github.com/erhant/circomkit/issues/88) right now until we can have a complete setup guide.
 
 ### Proof Tester
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,31 @@ You can compute the witness via the `calculateWitness(input)` function. To test 
 > });
 > ```
 
+#### Using C Tester
+
+You can make use of C-based tester as well. There is a prerequisite:
+
+- Install `nlohmann-json` header that is included within the C code:
+- Install `nasm`
+- Install `gmp` (GNU Multi-precision Arithmetic Library)
+
+> [!TIP]
+>
+> If you are using Mac you can do these with brew:
+>
+> ```sh
+>
+> # install required stuff
+> brew install nlohmann-json
+> brew install nasm
+> brew install gmp
+>
+> # add brew to path if required, path may differ M2 / M1
+> export CPLUS_INCLUDE_PATH="$CPLUS_INCLUDE_PATH:/opt/homebrew/include/"
+> export LIBRARY_PATH="$LIBRARY_PATH:/opt/homebrew/lib"
+> export INCLUDE_PATH="$INCLUDE_PATH:/opt/homebrew/include"
+> ```
+
 ### Proof Tester
 
 As an alternative to simulate generating a proof and verifying it, you can use Proof Tester. The proof tester makes use of WASM file, prover key and verifier key in the background. It will use the underlying Circomkit configuration to look for those files, and it can generate them automatically if they do not exist. An example using Plonk protocol is given below. Notice how we create the necessary files before creating the tester, as they are required for proof generation and verification.

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   testEnvironment: 'node',
   verbose: true,
   rootDir: './tests',
+  testTimeout: 100000,
   globalTeardown: '<rootDir>/hooks/teardown.js',
   forceExit: true,
   detectOpenHandles: true,

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -3,12 +3,15 @@ import * as snarkjs from 'snarkjs';
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-expect-error
 import {wasm as wasm_tester} from 'circom_tester';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+import {c as c_tester} from 'circom_tester';
 import {writeFileSync, readFileSync, existsSync, mkdirSync, rmSync, renameSync} from 'fs';
 import {readFile, rm, writeFile} from 'fs/promises';
 import {randomBytes} from 'crypto';
 import loglevel from 'loglevel';
 import {downloadPtau, getPtauName} from '../utils/ptau';
-import type {CircuitConfig, CircuitSignals, CircomWasmTester} from '../types';
+import type {CircuitConfig, CircuitSignals, CircomTester} from '../types';
 import {WitnessTester, ProofTester} from '../testers';
 import {prettyStringify} from '../utils';
 import {CircomkitConfig, DEFAULT, PRIMES, PROTOCOLS} from '../configs';
@@ -486,12 +489,13 @@ export class Circomkit {
   /** Compiles the circuit and returns a witness tester instance. */
   async WitnessTester<IN extends string[] = [], OUT extends string[] = []>(
     circuit: string,
-    circuitConfig: CircuitConfig & {recompile?: boolean}
+    circuitConfig: CircuitConfig & {recompile?: boolean},
+    tester: 'wasm' | 'c' = 'wasm'
   ) {
     circuitConfig.dir ??= 'test'; // defaults to test directory
 
     const targetPath = this.instantiate(circuit, circuitConfig);
-    const circomWasmTester: CircomWasmTester = await wasm_tester(targetPath, {
+    const circomWasmTester: CircomTester = await (tester === 'wasm' ? wasm_tester : c_tester)(targetPath, {
       output: undefined, // this makes tests to be created under /tmp
       prime: this.config.prime,
       verbose: this.config.verbose,

--- a/src/testers/witnessTester.ts
+++ b/src/testers/witnessTester.ts
@@ -1,5 +1,5 @@
 import {AssertionError} from 'node:assert';
-import type {CircomWasmTester, WitnessType, CircuitSignals, SymbolsType, SignalValueType} from '../types/';
+import type {CircomTester, WitnessType, CircuitSignals, SymbolsType, SignalValueType} from '../types/';
 
 // @todo detect optimized symbols https://github.com/erhant/circomkit/issues/80
 
@@ -12,12 +12,12 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
 
   constructor(
     /** The underlying `circom_tester` object */
-    private readonly circomWasmTester: CircomWasmTester
+    private readonly circomTester: CircomTester
   ) {}
 
   /** Assert that constraints are valid for a given witness. */
   async expectConstraintPass(witness: WitnessType): Promise<void> {
-    return this.circomWasmTester.checkConstraints(witness);
+    return this.circomTester.checkConstraints(witness);
   }
 
   /**
@@ -41,7 +41,7 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
 
   /** Compute witness given the input signals. */
   async calculateWitness(input: CircuitSignals<IN>): Promise<WitnessType> {
-    return this.circomWasmTester.calculateWitness(input, false);
+    return this.circomTester.calculateWitness(input, false);
   }
 
   /** Returns the number of constraints. */
@@ -287,13 +287,13 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
    * @param expectedOut computed output signals
    */
   private assertOut(actualOut: WitnessType, expectedOut: CircuitSignals<OUT>): Promise<void> {
-    return this.circomWasmTester.assertOut(actualOut, expectedOut);
+    return this.circomTester.assertOut(actualOut, expectedOut);
   }
 
   /** Loads the list of R1CS constraints to `this.constraints`. */
   private async loadConstraints(): Promise<void> {
-    await this.circomWasmTester.loadConstraints();
-    this.constraints = this.circomWasmTester.constraints;
+    await this.circomTester.loadConstraints();
+    this.constraints = this.circomTester.constraints;
   }
 
   /**
@@ -310,8 +310,8 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
   private async loadSymbols(): Promise<void> {
     // no need to check if symbols are already defined
     // that check happens within circomWasmTester
-    await this.circomWasmTester.loadSymbols();
-    this.symbols = this.circomWasmTester.symbols;
+    await this.circomTester.loadSymbols();
+    this.symbols = this.circomTester.symbols;
   }
 
   /**
@@ -319,7 +319,7 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
    * @param witness witness
    */
   private getDecoratedOutput(witness: WitnessType): Promise<string> {
-    return this.circomWasmTester.getDecoratedOutput(witness);
+    return this.circomTester.getDecoratedOutput(witness);
   }
 
   /**
@@ -327,6 +327,6 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
    * @deprecated this is buggy right now
    */
   private release(): Promise<void> {
-    return this.circomWasmTester.release();
+    return this.circomTester.release();
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -53,7 +53,7 @@ export type CircuitConfig = {
  * Not all functions may exist here, some are omitted.
  * @see https://github.com/iden3/circom_tester/blob/main/wasm/tester.js
  */
-export type CircomWasmTester = {
+export type CircomTester = {
   checkConstraints: (witness: WitnessType) => Promise<void>;
   release: () => Promise<void>;
   assertOut: (actualOut: WitnessType, expectedOut: CircuitSignals) => Promise<void>;

--- a/tests/common/circuits.ts
+++ b/tests/common/circuits.ts
@@ -33,7 +33,7 @@ type PreparedTestCircuit<S extends Record<string, CircuitSignals>> = {
  */
 export function prepareMultiplier(N: number, order: bigint = primes['bn128']) {
   const name = `multiplier_${N}`;
-  const config = {
+  const config: CircuitConfig = {
     file: 'multiplier',
     template: 'Multiplier',
     params: [N],

--- a/tests/witnessTester.test.ts
+++ b/tests/witnessTester.test.ts
@@ -1,6 +1,8 @@
 import {Circomkit, WitnessTester} from '../src';
 import {prepareMultiplier} from './common';
 
+// TODO: add C tester
+
 describe('witness tester', () => {
   let circuit: WitnessTester<['in'], ['out']>;
   const {
@@ -18,7 +20,7 @@ describe('witness tester', () => {
       dirInputs: './tests/inputs',
       dirBuild: './tests/build',
     });
-    circuit = await circomkit.WitnessTester(name, {...config, recompile: true}, 'c');
+    circuit = await circomkit.WitnessTester(name, {...config, recompile: true});
   });
 
   it('should have correct number of constraints', async () => {

--- a/tests/witnessTester.test.ts
+++ b/tests/witnessTester.test.ts
@@ -18,7 +18,7 @@ describe('witness tester', () => {
       dirInputs: './tests/inputs',
       dirBuild: './tests/build',
     });
-    circuit = await circomkit.WitnessTester(name, config);
+    circuit = await circomkit.WitnessTester(name, {...config, recompile: true}, 'c');
   });
 
   it('should have correct number of constraints', async () => {


### PR DESCRIPTION
Wonder how far we can go with simply adding `tester: 'wasm' | 'c' = 'wasm'` parameter to `WitnessTester` (defaults so to not be breaking change) and then do:

```sh
    const circomTester: CircomTester = await (tester === 'wasm' ? wasm_tester : c_tester)(targetPath, {
      output: undefined, // this makes tests to be created under /tmp
      prime: this.config.prime,
      verbose: this.config.verbose,
      O: Math.min(this.config.optimization, 1), // tester doesnt have O2
      json: false,
      include: this.config.include,
      wasm: true,
      sym: true,
      recompile: circuitConfig.recompile ?? true,
    });
```

using the same interface for both (`circomWasmTester` has been renamed).

Sadly, I could not test it because im on Mac M2 and I cant get `nasm` to output `arm64`, the compiler fails during the linking step due to:

```sh
 ld: symbol(s) not found for architecture arm64
 ```
