### PR TITLE
Default optimization level matches circom compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ npx circomkit calldata <circuit> <input>
 
 ### Circomkit Configurations
 
-Everything used by Circomkit can be optionally overridden by providing the selected fields in its constructor. Circomkit CLI does this automatically by checking out `circomkit.json` and overriding the defaults with that. You can print the active configuration via the following command:
+Everything used by Circomkit can be optionally overridden by providing the selected fields in its constructor. Circomkit CLI does this automatically by checking out [`circomkit.json`](src/configs/index.ts#L56) and overriding the defaults with that. You can print the active configuration via the following command:
 
 ```sh
 npx circomkit config

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -31,9 +31,10 @@ export type CircomkitConfig = {
   version: `${number}.${number}.${number}`;
   /**
    * [Optimization level](https://docs.circom.io/getting-started/compilation-options/#flags-and-options-related-to-the-r1cs-optimization).
+   * Defaults to `2` as per the Circom defaults, see [`circom/src/input_user.rs`](https://github.com/iden3/circom/blob/master/circom/src/input_user.rs#L249).
    * - `0`: No simplification is applied.
    * - `1`: Only applies `var` to `var` and `var` to `constant` simplification.
-   * - `2`: Full constraint simplificiation via Gaussian eliminations.
+   * - `2`: Full constraint simplificiation via Gaussian eliminations. (Default)
    * - `>2`: Any number higher than 2 will use `--O2round` with the number as simplification rounds.
    */
   optimization: number;

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -65,7 +65,7 @@ export const DEFAULT = Object.seal<Readonly<CircomkitConfig>>({
   dirBuild: './build',
   circomPath: 'circom',
   // compiler-specific
-  optimization: 1,
+  optimization: 2,
   inspect: true,
   include: ['./node_modules'],
   cWitness: false,

--- a/tests/configs.test.ts
+++ b/tests/configs.test.ts
@@ -100,6 +100,11 @@ describe('compiling circuits with custom_templates', () => {
 });
 
 describe('compiling under different directories', () => {
+
+  // Fibonacci circuits have only addition constraints so
+  // optimization levels >= 2 result in zero constraints and an invalid r1cs
+  const optimizationLevels = [0, 1];
+
   const cases = [
     {
       file: 'fibonacci/vanilla',
@@ -113,20 +118,21 @@ describe('compiling under different directories', () => {
     },
   ] as const;
 
-  cases.map(testcase =>
-    describe(`circomkit with explicit config & input (${testcase.circuit})`, () => {
+  optimizationLevels.map(optimization => cases.map(testcase =>
+    describe(`circomkit with explicit config (--O${optimization}) & input (${testcase.circuit})`, () => {
       let circomkit: Circomkit;
 
       beforeAll(() => {
         circomkit = new Circomkit({
           protocol: 'groth16',
+          optimization,
           verbose: false,
           logLevel: 'silent',
           circuits: './tests/circuits.json',
           dirPtau: './tests/ptau',
           dirCircuits: './tests/circuits',
           dirInputs: './tests/inputs',
-          dirBuild: './tests/build',
+          dirBuild: `./tests/build/o${optimization}`,
         });
       });
 
@@ -150,5 +156,5 @@ describe('compiling under different directories', () => {
         expect(isVerified).toBe(true);
       });
     })
-  );
+  ));
 });


### PR DESCRIPTION
Hi Erhan,

I've been compiling [Anon Aadhaar](https://circuitscan.org/chain/11155111/address/0x72687fAbC8F025233C6aA5c2a9Cf092365ed741D#source-code) and [ZK-p2p](https://circuitscan.org/chain/11155111/address/0x84ac07EfC0c7093416aCd6189a600AD479CFA045) circuits using their final Zkeys from [DefinitelySetup](https://ceremony.pse.dev) and have found that I have to set the optimization level to 2 for each of these, the default value when invoking circom without any optimization flag set. I propose aligning circomkit with the default used by the compiler.

This is just a draft because it breaks the tests. If you agree, I'll take a look at fixing the tests.

Ben 

