### PR TITLE
Add teardown to cli commands

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -4,6 +4,7 @@ import {Circomkit} from './core';
 import {existsSync, readFileSync, readdirSync, writeFileSync} from 'fs';
 import {prettyStringify} from './utils';
 import {exec} from 'child_process';
+import {teardown} from './utils/teardown';
 
 const CONFIG_PATH = './circomkit.json';
 
@@ -18,6 +19,7 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = await circomkit.compile(circuit);
       circomkit.log.info('Built at:', path);
+      teardown();
 
       // TODO: pattern matching https://github.com/erhant/circomkit/issues/79
     });
@@ -29,6 +31,7 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = circomkit.instantiate(circuit);
       circomkit.log.info('Created at:', path);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -44,6 +47,7 @@ function cli(args: string[]) {
       console.log(`Number of Public Inputs: ${info.publicInputs}`);
       console.log(`Number of Public Outputs: ${info.publicOutputs}`);
       console.log(`Number of Labels: ${info.labels}`);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -53,6 +57,7 @@ function cli(args: string[]) {
     .action(async circuit => {
       await circomkit.clear(circuit);
       circomkit.log.info('Cleaned.');
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -73,6 +78,7 @@ function cli(args: string[]) {
       }
 
       circomkit.log.info('Circomkit project initialized! ✨');
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -88,6 +94,7 @@ function cli(args: string[]) {
           const {json, path} = await circomkit.json('r1cs', circuit);
           writeFileSync(path, prettyStringify(json));
           circomkit.log.info('Exported R1CS at: ' + path);
+          teardown();
         })
     )
     .addCommand(
@@ -98,6 +105,7 @@ function cli(args: string[]) {
           const {json, path} = await circomkit.json('zkey', circuit);
           writeFileSync(path, prettyStringify(json));
           circomkit.log.info('Exported prover key at: ' + path);
+          teardown();
         })
     )
     .addCommand(
@@ -109,6 +117,7 @@ function cli(args: string[]) {
           const {json, path} = await circomkit.json('wtns', circuit, input);
           writeFileSync(path, prettyStringify(json));
           circomkit.log.info('Exported prover key at: ' + path);
+          teardown();
         })
     );
 
@@ -119,6 +128,7 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = await circomkit.contract(circuit);
       circomkit.log.info('Created at: ' + path);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -129,6 +139,7 @@ function cli(args: string[]) {
     .action(async (circuit, input) => {
       const calldata = await circomkit.calldata(circuit, input);
       circomkit.log.info(calldata);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -139,6 +150,7 @@ function cli(args: string[]) {
     .action(async (circuit, pkeyPath) => {
       const path = await circomkit.vkey(circuit, pkeyPath);
       circomkit.log.info('Created at: ' + path);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -149,6 +161,7 @@ function cli(args: string[]) {
     .action(async (circuit, input) => {
       const path = await circomkit.prove(circuit, input);
       circomkit.log.info('Generated at: ' + path);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -163,6 +176,7 @@ function cli(args: string[]) {
       } else {
         circomkit.log.info('Verification failed!');
       }
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -173,6 +187,7 @@ function cli(args: string[]) {
     .action(async (circuit, input) => {
       const path = await circomkit.witness(circuit, input);
       circomkit.log.info('Witness created: ' + path);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -184,6 +199,7 @@ function cli(args: string[]) {
       const {proverKeyPath, verifierKeyPath} = await circomkit.setup(circuit, ptauPath);
       circomkit.log.info('Prover key created: ' + proverKeyPath);
       circomkit.log.info('Verifier key created: ' + verifierKeyPath);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -193,6 +209,7 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = await circomkit.ptau(circuit);
       circomkit.log.info('PTAU ready at: ' + path);
+      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -211,12 +228,16 @@ function cli(args: string[]) {
           .map((c, i) => `  ${i + 1}. ${c}`)
           .join('\n')
     );
+    teardown();
   });
 
   ///////////////////////////////////////////////////////////////////////////////
   const config = new Command('config')
     .description('print configuration')
-    .action(() => circomkit.log.info(circomkit.config));
+    .action(() => {
+      circomkit.log.info(circomkit.config)
+      teardown();
+    });
 
   ///////////////////////////////////////////////////////////////////////////////
   new Command()

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -243,7 +243,7 @@ function cli(args: string[]) {
     .addCommand(verify)
     .addCommand(calldata)
     // teardown to terminate SnarkJS, otherwise hangs the program
-    .hook('postAction', () => teardown())
+    .hook('postAction', async () => await teardown())
     .parse(args);
 
   // TODO: test graceful exits

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,7 +19,6 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = await circomkit.compile(circuit);
       circomkit.log.info('Built at:', path);
-      teardown();
 
       // TODO: pattern matching https://github.com/erhant/circomkit/issues/79
     });
@@ -31,7 +30,6 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = circomkit.instantiate(circuit);
       circomkit.log.info('Created at:', path);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -47,7 +45,6 @@ function cli(args: string[]) {
       console.log(`Number of Public Inputs: ${info.publicInputs}`);
       console.log(`Number of Public Outputs: ${info.publicOutputs}`);
       console.log(`Number of Labels: ${info.labels}`);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -57,7 +54,6 @@ function cli(args: string[]) {
     .action(async circuit => {
       await circomkit.clear(circuit);
       circomkit.log.info('Cleaned.');
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -78,7 +74,6 @@ function cli(args: string[]) {
       }
 
       circomkit.log.info('Circomkit project initialized! ✨');
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -94,7 +89,6 @@ function cli(args: string[]) {
           const {json, path} = await circomkit.json('r1cs', circuit);
           writeFileSync(path, prettyStringify(json));
           circomkit.log.info('Exported R1CS at: ' + path);
-          teardown();
         })
     )
     .addCommand(
@@ -105,7 +99,6 @@ function cli(args: string[]) {
           const {json, path} = await circomkit.json('zkey', circuit);
           writeFileSync(path, prettyStringify(json));
           circomkit.log.info('Exported prover key at: ' + path);
-          teardown();
         })
     )
     .addCommand(
@@ -117,7 +110,6 @@ function cli(args: string[]) {
           const {json, path} = await circomkit.json('wtns', circuit, input);
           writeFileSync(path, prettyStringify(json));
           circomkit.log.info('Exported prover key at: ' + path);
-          teardown();
         })
     );
 
@@ -128,7 +120,6 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = await circomkit.contract(circuit);
       circomkit.log.info('Created at: ' + path);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -139,7 +130,6 @@ function cli(args: string[]) {
     .action(async (circuit, input) => {
       const calldata = await circomkit.calldata(circuit, input);
       circomkit.log.info(calldata);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -150,7 +140,6 @@ function cli(args: string[]) {
     .action(async (circuit, pkeyPath) => {
       const path = await circomkit.vkey(circuit, pkeyPath);
       circomkit.log.info('Created at: ' + path);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -161,7 +150,6 @@ function cli(args: string[]) {
     .action(async (circuit, input) => {
       const path = await circomkit.prove(circuit, input);
       circomkit.log.info('Generated at: ' + path);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -176,7 +164,6 @@ function cli(args: string[]) {
       } else {
         circomkit.log.info('Verification failed!');
       }
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -187,7 +174,6 @@ function cli(args: string[]) {
     .action(async (circuit, input) => {
       const path = await circomkit.witness(circuit, input);
       circomkit.log.info('Witness created: ' + path);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -199,7 +185,6 @@ function cli(args: string[]) {
       const {proverKeyPath, verifierKeyPath} = await circomkit.setup(circuit, ptauPath);
       circomkit.log.info('Prover key created: ' + proverKeyPath);
       circomkit.log.info('Verifier key created: ' + verifierKeyPath);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -209,7 +194,6 @@ function cli(args: string[]) {
     .action(async circuit => {
       const path = await circomkit.ptau(circuit);
       circomkit.log.info('PTAU ready at: ' + path);
-      teardown();
     });
 
   ///////////////////////////////////////////////////////////////////////////////
@@ -228,16 +212,12 @@ function cli(args: string[]) {
           .map((c, i) => `  ${i + 1}. ${c}`)
           .join('\n')
     );
-    teardown();
   });
 
   ///////////////////////////////////////////////////////////////////////////////
-  const config = new Command('config')
-    .description('print configuration')
-    .action(() => {
-      circomkit.log.info(circomkit.config)
-      teardown();
-    });
+  const config = new Command('config').description('print configuration').action(() => {
+    circomkit.log.info(circomkit.config);
+  });
 
   ///////////////////////////////////////////////////////////////////////////////
   new Command()
@@ -262,6 +242,8 @@ function cli(args: string[]) {
     .addCommand(witness)
     .addCommand(verify)
     .addCommand(calldata)
+    // teardown to terminate SnarkJS, otherwise hangs the program
+    .hook('postAction', () => teardown())
     .parse(args);
 
   // TODO: test graceful exits

--- a/src/utils/teardown.ts
+++ b/src/utils/teardown.ts
@@ -1,0 +1,8 @@
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-var
+  var curve_bn128: any;
+}
+
+export function teardown() {
+  if (globalThis.curve_bn128) globalThis.curve_bn128.terminate();
+}

--- a/src/utils/teardown.ts
+++ b/src/utils/teardown.ts
@@ -1,8 +1,15 @@
 declare global {
   // eslint-disable-next-line no-var
-  var curve_bn128: {terminate: () => void} | undefined;
+  var curve_bn128: {terminate: () => Promise<void>} | undefined;
 }
 
-export function teardown() {
-  if (globalThis.curve_bn128) globalThis.curve_bn128.terminate();
+/**
+ * Teardown function to be run for graceful exits.
+ *
+ * SnarkJS may attach curve_bn128 to global, but does not terminate it.
+ * We have to do it manually (see https://github.com/iden3/snarkjs/issues/152)
+ * For this, we use the [`terminate`](https://github.com/iden3/ffjavascript/blob/master/src/bn128.js#L48) function.
+ */
+export async function teardown() {
+  if (globalThis.curve_bn128) await globalThis.curve_bn128.terminate();
 }

--- a/src/utils/teardown.ts
+++ b/src/utils/teardown.ts
@@ -1,6 +1,6 @@
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any, no-var
-  var curve_bn128: any;
+  // eslint-disable-next-line no-var
+  var curve_bn128: {terminate: () => void} | undefined;
 }
 
 export function teardown() {


### PR DESCRIPTION
Added the `teardown` script to all CLI commands. Solves #95 

Note: While not all commands need tearing down, this pattern will keep the code maintainable. 