### PR TITLE
WitnessTester.compute supports multiple output signals

### DIFF
--- a/src/testers/witnessTester.ts
+++ b/src/testers/witnessTester.ts
@@ -222,7 +222,8 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
       // non-main signals have an additional `.` in them after `main.symbol`
       const signalDotCount = dotCount(signal) + 1; // +1 for the dot in `main.`
       const signalLength = signal.length + 5; // +5 for prefix `main.`
-      const symbolNames = Object.keys(this.symbols!).filter(s => signalDotCount === dotCount(s));
+      const symbolNames = Object.keys(this.symbols!).filter(s =>
+        s.startsWith(`main.${signal}`) && signalDotCount === dotCount(s));
 
       // get the symbol values from symbol names, ignoring `main.` prefix
       // the matched symbols must exactly equal the signal


### PR DESCRIPTION
Hey Erhan, quick update:

Without this fix, the output signals are not fetched correctly.

They're all the same and wrong values/lengths:
```
{
      aOut: [
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n,
        ... 233 more items
      ],
      bOut: [
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n,
        ... 233 more items
      ],
      cOut: [
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n, 6n,
        6n, 6n, 6n, 6n,
        ... 233 more items
      ]
    }
```