### PR TITLE
Human-readable constraint display

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,17 @@ it('should have correct number of constraints', async () => {
 });
 ```
 
+> <picture>
+>   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/light-theme/tip.svg">
+>   <img alt="Warning" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/main/blockquotes/badge/dark-theme/tip.svg">
+> </picture><br>
+>
+> You can also generate an array of human-readable formulas for each constraint using `parseConstraints`:
+>
+> ```ts
+> console.log((await circuit.parseConstraints()).join('\n'));
+> ```
+
 If you want more control over the output signals, you can use the `compute` function. It takes in an input, and an array of output signal names used in the `main` component so that they can be extracted from the witness.
 
 ```ts

--- a/src/testers/witnessTester.ts
+++ b/src/testers/witnessTester.ts
@@ -223,7 +223,7 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
       const signalDotCount = dotCount(signal) + 1; // +1 for the dot in `main.`
       const signalLength = signal.length + 5; // +5 for prefix `main.`
       const symbolNames = Object.keys(this.symbols!).filter(
-        s => s.startsWith(`main.${signal}`) && signalDotCount === dotCount(s)
+        s => s.match(new RegExp(`^main\\.${signal}(\\[|$|\\.)`)) && signalDotCount === dotCount(s)
       );
 
       // get the symbol values from symbol names, ignoring `main.` prefix

--- a/src/testers/witnessTester.ts
+++ b/src/testers/witnessTester.ts
@@ -166,13 +166,13 @@ export class WitnessTester<IN extends readonly string[] = [], OUT extends readon
         const vars = Object.keys(item).reduce((out, cur) => {
           // @ts-ignore
           const coeffRaw = item[cur];
-          const coeff = coeffRaw > fieldSize / 2n ? coeffRaw - fieldSize : coeffRaw;
+          const coeff = coeffRaw > fieldSize / BigInt(2) ? coeffRaw - fieldSize : coeffRaw;
           // @ts-ignore
           const varName = varsById[cur];
           out.push(
             // @ts-ignore
-            coeff === -1n && varName ? '-' + varName :
-            coeff === 1n && varName ? varName :
+            coeff === BigInt(-1) && varName ? '-' + varName :
+            coeff === BigInt(1) && varName ? varName :
             !varName ? `${coeff}` :
             `(${coeff} * ${varName})`,
           );

--- a/tests/witnessTester.test.ts
+++ b/tests/witnessTester.test.ts
@@ -31,6 +31,22 @@ describe('witness tester', () => {
     // should also work for non-exact too, where we expect at least some amount
     await circuit.expectConstraintCount(size!);
     await circuit.expectConstraintCount(size! - 1);
+
+    const parsedConstraints = await circuit.parseConstraints();
+
+    expect(parsedConstraints.join('\n')).toEqual(
+`-main.in[0] * main.in[1] + main.inner[0] = 0
+-main.inner[0] * main.in[2] + main.inner[1] = 0
+-main.inner[1] * main.in[3] + main.out = 0
+main.isZero[0].in * main.isZero[0].inv - 1 = 0
+main.isZero[1].in * main.isZero[1].inv - 1 = 0
+main.isZero[2].in * main.isZero[2].inv - 1 = 0
+main.isZero[3].in * main.isZero[3].inv - 1 = 0
+-1 + main.in[0] - main.isZero[0].in = 0
+-1 + main.in[1] - main.isZero[1].in = 0
+-1 + main.in[2] - main.isZero[2].in = 0
+-1 + main.in[3] - main.isZero[3].in = 0`);
+
   });
 
   it('should assert correctly', async () => {


### PR DESCRIPTION
I wrote this function to make it easier to understand my circuits. What do you think about this? It's a lot nicer than `snarkjs rp mycircuit.r1cs`. I'll have to come up with something better than that giant string block in the test case before merging.

Sorry about just ignoring all the ts errors :rofl: 

Also, the `compute` match fix is in here. I tried a few more tests but I couldn't get it to fail like I thought it might so there's no test change for it.