### PR TITLE
Speed up readWitness() up to 10x, only load requested symbols

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -63,4 +63,6 @@ export type CircomTester = {
   loadSymbols: () => Promise<void>;
   symbols: SymbolsType | undefined;
   getDecoratedOutput: (witness: WitnessType) => Promise<string>;
+  dir: string;
+  baseName: string;
 };


### PR DESCRIPTION
### The problem

I'm working on a circuit that needs to do EC scalar multiplication on curve25519 points. 

A single call to scalarMult() creates a circuit with 5,500,000 symbols, currently (still hoping to optimize this more).

Calling `WitnessTester.readWitness()` was taking ~6 seconds each time.

I observed that 99% of `readWitness()`'s runtime was spent in `this.loadSymbols()`, which calls [`circomTester.loadSymbols()`](https://github.com/iden3/circom_tester/blob/67082a8c276b422dee82400f285f59d1d01d9ea9/wasm/tester.js#L116), the source of the logic to process and load the symbols file.

It was processing and loading all 5.5M symbols into memory, even though I only needed the first 12.

### Solution

I created a new function `loadSpecificSymbols(symbolsRequested: string[])`. It uses the same logic as `circomTester.loadSymbols()`, but stops once all the input symbols are found.

### Results

For my large scalarMult() circuit, this brought the `readWitness()` runtime down from ~6.5 seconds to ~0.6 seconds, approx **10x faster**.

The effect on smaller circuits was negligible— they were already fast and they stayed fast.

I suspect it could give even faster speed ups for larger circuits, but haven't tested that yet.

### Before

( Note: getSignals() here is the one that calls `readWitness()` )

<img width="585" alt="image" src="https://github.com/user-attachments/assets/5a905ad2-cd14-444b-9cbd-a7da40ff0153" />

### After

<img width="613" alt="image" src="https://github.com/user-attachments/assets/6fda6ac5-b77b-44f7-8f3c-ffc7d8bda6d1" />


### Interface

The interface of `readWitness()` stays the same, no changes are required on the consumer's part. 

But in my own testing, I observed that the speed up is best realized by calling `readWitness()` **a single time** with an array of all the desired signals. 

This is significantly faster than calling it once for each signal. 

In the old version, there was negligible speed difference whether called once or individually, because the loaded symbols were already being cached.

I made sure to preserve the cache in this new `loadSpecificSymbols()` function too.
