### PR TITLE
remove confusing log

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -338,8 +338,6 @@ export class Circomkit {
 
     // get ptau path
     if (ptauPath === undefined) {
-      this.log.info('No PTAU was provided, downloading it.');
-      // if no ptau is given, we can download it
       if (this.config.prime !== 'bn128') {
         throw new Error('Can not download PTAU file when using a prime field other than bn128');
       }


### PR DESCRIPTION
![telegram-cloud-photo-size-5-6150065664187025962-y](https://github.com/user-attachments/assets/e92e4adb-0687-40fc-a864-c7132e68caac)

Currently circomkit prints "No PTAU was provided, downloading it." even if the ptau locally exists.

This PR removes the redundant log so that it prints downloading log only if it ptau doesn't exist.