### PR TITLE
Add skipWasm circomkit config setting

### DIFF
--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -49,8 +49,8 @@ export type CircomkitConfig = {
   logLevel: LogLevelDesc;
   /** Whether to generate the C witness calculator. */
   cWitness: boolean;
-  /** Whether to skip generating the WASM witness calculator. */
-  skipWasm: boolean;
+  /** Whether to generate the WASM witness calculator. */
+  wasmWitness: boolean;
   /** Whether to print Solidity copy-pasteable calldata. */
   prettyCalldata: false;
 };
@@ -73,7 +73,7 @@ export const DEFAULT = Object.seal<Readonly<CircomkitConfig>>({
   inspect: true,
   include: ['./node_modules'],
   cWitness: false,
-  skipWasm: false,
+  wasmWitness: true,
   // groth16 phase-2 settings
   groth16numContributions: 1,
   groth16askForEntropy: false,

--- a/src/configs/index.ts
+++ b/src/configs/index.ts
@@ -49,6 +49,8 @@ export type CircomkitConfig = {
   logLevel: LogLevelDesc;
   /** Whether to generate the C witness calculator. */
   cWitness: boolean;
+  /** Whether to skip generating the WASM witness calculator. */
+  skipWasm: boolean;
   /** Whether to print Solidity copy-pasteable calldata. */
   prettyCalldata: false;
 };
@@ -71,6 +73,7 @@ export const DEFAULT = Object.seal<Readonly<CircomkitConfig>>({
   inspect: true,
   include: ['./node_modules'],
   cWitness: false,
+  skipWasm: false,
   // groth16 phase-2 settings
   groth16numContributions: 1,
   groth16askForEntropy: false,

--- a/src/functions/circuit.ts
+++ b/src/functions/circuit.ts
@@ -16,11 +16,12 @@ export async function compileCircuit(config: CircomkitConfig, targetPath: string
   mkdirSync(outDir, {recursive: true});
 
   // prettier-ignore
-  let flags = `--sym --wasm --r1cs -p ${config.prime} -o ${outDir}`;
+  let flags = `--sym --r1cs -p ${config.prime} -o ${outDir}`;
   if (config.include.length > 0) flags += ' ' + config.include.map(path => `-l ${path}`).join(' ');
   if (config.verbose) flags += ' --verbose';
   if (config.inspect) flags += ' --inspect';
   if (config.cWitness) flags += ' --c';
+  if (!config.skipWasm) flags += ' --wasm';
   if (typeof config.optimization === 'number') {
     if (config.optimization > 2) {
       // --O2round <value>

--- a/src/functions/circuit.ts
+++ b/src/functions/circuit.ts
@@ -21,7 +21,7 @@ export async function compileCircuit(config: CircomkitConfig, targetPath: string
   if (config.verbose) flags += ' --verbose';
   if (config.inspect) flags += ' --inspect';
   if (config.cWitness) flags += ' --c';
-  if (!config.skipWasm) flags += ' --wasm';
+  if (config.wasmWitness) flags += ' --wasm';
   if (typeof config.optimization === 'number') {
     if (config.optimization > 2) {
       // --O2round <value>


### PR DESCRIPTION
Hey Erhan,

How's it going? I've come across a limit of using circomkit for very large circuits:

```
thread 'main' panicked at code_producers/src/wasm_elements/wasm_code_generator.rs:9:5:
the size of memory needs addresses beyond 32 bits long. This circuit cannot be run on WebAssembly
 Try to run circom --c in order to generate c++ code instead
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

So I've added this config option to skip passing the wasm flag to circom.

I'm going to test it out then I'll update this from draft status.