### PR TITLE
fix: honor this.config.version in instantiate() fallback (#123)

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -264,7 +264,8 @@ export class Circomkit {
     const config: Required<CircuitConfig> = {
       file: file,
       template: circuitConfig.template,
-      version: circuitConfig.version || '2.0.0',
+      // Precedence: per-circuit override > this.config.version > "2.0.0". See #123.
+      version: circuitConfig.version || this.config.version || '2.0.0',
       dir: directory,
       pubs: circuitConfig.pubs || [],
       params: circuitConfig.params || [],

--- a/tests/circomkit.test.ts
+++ b/tests/circomkit.test.ts
@@ -157,3 +157,40 @@ describe('circomkit', () => {
     })
   );
 });
+
+describe('instantiate version fallback (#123)', () => {
+  const {circuit} = prepareMultiplier(3);
+  const baseConfig = {
+    verbose: false,
+    logLevel: 'silent' as const,
+    circuits: './tests/circuits.json',
+    dirPtau: './tests/ptau',
+    dirCircuits: './tests/circuits',
+    dirInputs: './tests/inputs',
+    dirBuild: './tests/build',
+  };
+
+  it('should use this.config.version when circuitConfig has no version field', () => {
+    const customVersion = '2.1.9';
+    const circomkit = new Circomkit({...baseConfig, version: customVersion});
+
+    const path = circomkit.instantiate('multiplier_version_fallback', circuit.config);
+    const content = readFileSync(path, 'utf-8');
+    expect(content).toContain(`pragma circom ${customVersion};`);
+
+    rmSync(path);
+  });
+
+  it('should prefer circuitConfig.version over this.config.version', () => {
+    const circomkit = new Circomkit({...baseConfig, version: '2.1.9'});
+
+    const path = circomkit.instantiate('multiplier_version_override', {
+      ...circuit.config,
+      version: '2.2.0',
+    });
+    const content = readFileSync(path, 'utf-8');
+    expect(content).toContain('pragma circom 2.2.0;');
+
+    rmSync(path);
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #123. One-line fix in `instantiate()`: the version fallback now honors `this.config.version` before defaulting to `"2.0.0"`. The previous hardcoded fallback caused `WitnessTester` calls (which always pass an inline `circuitConfig` without a `version` field) to regenerate the scaffolding circoms at pragma `2.0.0` regardless of the project's configured version.

## Changes

- `src/core/index.ts`: `version: circuitConfig.version || '2.0.0'` → `version: circuitConfig.version || this.config.version || '2.0.0'`.
- `tests/circomkit.test.ts`: two new tests under `describe('instantiate version fallback (#123)')`:
  - `should use this.config.version when circuitConfig has no version field`, the fix.
  - `should prefer circuitConfig.version over this.config.version`, regression guard for the per-circuit override.

## Testing

`npx jest -t "version fallback"` → 2 passing.